### PR TITLE
Set ES 5.6 required status to yellow

### DIFF
--- a/search5/src/main/java/org/hibernate/performance/search/model/application/ModelServiceImpl.java
+++ b/search5/src/main/java/org/hibernate/performance/search/model/application/ModelServiceImpl.java
@@ -34,6 +34,7 @@ public class ModelServiceImpl implements ModelService {
 					"hibernate.search.default.elasticsearch.index_schema_management_strategy",
 					"drop-and-create-and-drop"
 			);
+			properties.put( "hibernate.search.default.elasticsearch.required_index_status", "yellow" );
 		}
 
 		if ( IndexingType.MANUAL.equals( indexing ) ) {


### PR DESCRIPTION
Using a single instance docker container, we have a yellow index status.